### PR TITLE
fix: ems:admin:command

### DIFF
--- a/bin/elasticms
+++ b/bin/elasticms
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-php -d memory_limit=${CLI_PHP_MEMORY_LIMIT:-512M} /opt/src/elasticms/bin/console $@
+php -d memory_limit=${CLI_PHP_MEMORY_LIMIT:-512M} /opt/src/elasticms/bin/console "$@"


### PR DESCRIPTION
```bash
docker compose cli elasticms ems:admin:command 'ems:environment:rebuild preview --no-debug'                                                                                                                                                                               23:37:21 
[critical] Error thrown while running command "ems:admin:command 'ems:environment:rebuild' preview --no-debug". Message: "Too many arguments to "ems:admin:command" command, expected arguments "remote-command"."

 * Duration: 0 s
 * Memory: 8 MB



  Too many arguments to "ems:admin:command" command, expected arguments "remote-command".  

````