### PR TITLE
Freeze PHP v8.1.19 for EMS v5.6.x

### DIFF
--- a/Dockerfiles/Dockerfile.in
+++ b/Dockerfiles/Dockerfile.in
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.3
-FROM docker.io/elasticms/base-php:8.1.15-cli-dev as builder
+FROM docker.io/elasticms/base-php:8.1.19-cli-dev as builder
 
 # include(Args.m4)
 # include(Builder.m4)
 
-FROM docker.io/elasticms/base-php:8.1.15-cli as prd
+FROM docker.io/elasticms/base-php:8.1.19-cli as prd
 
 LABEL be.fgov.elasticms.client.environment="prd"
 
@@ -13,7 +13,7 @@ ENV NODE_ENV=production
 # include(Args.m4)
 # include(Common.m4)
 
-FROM docker.io/elasticms/base-php:8.1.15-cli-dev as dev
+FROM docker.io/elasticms/base-php:8.1.19-cli-dev as dev
 
 LABEL be.fgov.elasticms.client.environment="dev"
 

--- a/Dockerfiles/Dockerfile.in
+++ b/Dockerfiles/Dockerfile.in
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1.3
-FROM docker.io/elasticms/base-php:8.1-cli-dev as builder
+FROM docker.io/elasticms/base-php:8.1.15-cli-dev as builder
 
 # include(Args.m4)
 # include(Builder.m4)
 
-FROM docker.io/elasticms/base-php:8.1-cli as prd
+FROM docker.io/elasticms/base-php:8.1.15-cli as prd
 
 LABEL be.fgov.elasticms.client.environment="prd"
 
@@ -13,9 +13,10 @@ ENV NODE_ENV=production
 # include(Args.m4)
 # include(Common.m4)
 
-FROM docker.io/elasticms/base-php:8.1-cli-dev as dev
+FROM docker.io/elasticms/base-php:8.1.15-cli-dev as dev
 
 LABEL be.fgov.elasticms.client.environment="dev"
+
 ENV NODE_ENV=development
 
 # include(Args.m4)


### PR DESCRIPTION
Avoid any side-effects when upgrading the PHP base image (PHP, Curl, Alpine etc.).